### PR TITLE
Require reauthentication before adding passkeys

### DIFF
--- a/public/registration.ts
+++ b/public/registration.ts
@@ -1,3 +1,48 @@
+async function reauthenticateForPasskeyAddition() {
+  try {
+    const generateResponse = await fetch('/auth/webauthn/reauthentication/generate', {
+      method: 'GET',
+    });
+
+    const generateJson = await generateResponse.json();
+
+    if (!generateResponse.ok) {
+      alert(generateJson.message ?? '再認証の開始に失敗しました。');
+      return false;
+    }
+
+    const options = PublicKeyCredential.parseRequestOptionsFromJSON(generateJson);
+
+    const credential = await navigator.credentials.get({ publicKey: options });
+
+    if (!credential) {
+      alert('再認証がキャンセルされました。');
+      return false;
+    }
+
+    const verifyResponse = await fetch('/auth/webauthn/reauthentication/verify', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(credential),
+    });
+
+    const verifyJson = await verifyResponse.json();
+
+    if (!verifyResponse.ok || !verifyJson.success) {
+      alert(verifyJson.message ?? '再認証に失敗しました。もう一度お試しください。');
+      return false;
+    }
+
+    return true;
+  } catch (error) {
+    console.error(error);
+    alert('再認証に失敗しました。もう一度お試しください。');
+    return false;
+  }
+}
+
 async function handleRegistration(isNewAccount: boolean = true) {
   if (isNewAccount) {
     const usernameEle = document.getElementById('username');
@@ -19,15 +64,28 @@ async function handleRegistration(isNewAccount: boolean = true) {
       alert(json.message);
       return;
     }
+  } else {
+    const reauthenticated = await reauthenticateForPasskeyAddition();
+    if (!reauthenticated) {
+      return;
+    }
   }
 
   const generateRegistrationOptionsResponse = await fetch('/auth/webauthn/registration/generate', {
     method: 'GET',
   });
-  const options = PublicKeyCredential.parseCreationOptionsFromJSON(await generateRegistrationOptionsResponse.json());
+  const options = PublicKeyCredential.parseCreationOptionsFromJSON(
+    await generateRegistrationOptionsResponse.json()
+  );
   console.log(options);
 
   const credential = await navigator.credentials.create({ publicKey: options });
+
+  if (!credential) {
+    alert('パスキーの登録がキャンセルされました。');
+    return;
+  }
+
   const credentialResponse = await fetch('/auth/webauthn/registration/verify', {
     method: 'POST',
     headers: {
@@ -37,12 +95,12 @@ async function handleRegistration(isNewAccount: boolean = true) {
   });
 
   const credentialJson = await credentialResponse.json();
-  if (!credentialJson.success) {
+  if (!credentialResponse.ok || !credentialJson.success) {
     alert(credentialJson.message);
     return;
   }
 
-  if(isNewAccount) {
+  if (isNewAccount) {
     alert('新規登録が完了しました');
     location.href = '/auth/login';
   } else {

--- a/src/lib/auth/reauthSession.ts
+++ b/src/lib/auth/reauthSession.ts
@@ -1,0 +1,66 @@
+import type { Context } from 'hono';
+import { createRedisSessionStore } from '../redis/redis-session.js';
+import { deleteCookie, getCookie, setCookie } from 'hono/cookie';
+import { cookieOptions } from './cookie-options.js';
+import z from 'zod';
+
+const ReauthSessionDataSchema = z.object({
+  userID: z.string(),
+});
+
+type ReauthSessionData = z.infer<typeof ReauthSessionDataSchema>;
+
+const TTL_SEC = 60 * 5; // 5 minutes
+
+const reauthSessionStore = await createRedisSessionStore<ReauthSessionData>({
+  prefix: 'reauth',
+  ttlSec: TTL_SEC,
+  dataParser: (data: unknown) => {
+    const parsed = ReauthSessionDataSchema.safeParse(data);
+    return parsed.success ? parsed.data : undefined;
+  },
+});
+
+const REAUTH_COOKIE_NAME = 'ra';
+
+const reauthCookieOptions = {
+  ...cookieOptions,
+  maxAge: TTL_SEC,
+} as const;
+
+interface ReauthSessionController {
+  markReauthenticated(c: Context, userID: string): Promise<void>;
+  consumeReauthentication(c: Context, userID: string): Promise<boolean>;
+}
+
+const createReauthSessionController = (): ReauthSessionController => {
+  return {
+    markReauthenticated: async (c: Context, userID: string) => {
+      const currentSessionID = getCookie(c, REAUTH_COOKIE_NAME);
+      if (currentSessionID) {
+        await reauthSessionStore.destroy(currentSessionID);
+      }
+
+      const sessionID = await reauthSessionStore.createSessionWith({ userID });
+      setCookie(c, REAUTH_COOKIE_NAME, sessionID, reauthCookieOptions);
+    },
+    consumeReauthentication: async (c: Context, userID: string) => {
+      const sessionID = getCookie(c, REAUTH_COOKIE_NAME);
+      if (!sessionID) {
+        return false;
+      }
+
+      const sessionData = await reauthSessionStore.get(sessionID);
+      await reauthSessionStore.destroy(sessionID);
+      deleteCookie(c, REAUTH_COOKIE_NAME, reauthCookieOptions);
+
+      if (!sessionData) {
+        return false;
+      }
+
+      return sessionData.userID === userID;
+    },
+  };
+};
+
+export const reauthSessionController = createReauthSessionController();


### PR DESCRIPTION
## Summary
- introduce a dedicated reauthentication session store for short-lived redis-backed cookies
- require recent reauthentication when generating WebAuthn registration options for signed-in users and expose new REST endpoints to perform it
- update the registration frontend to trigger the reauthentication ceremony before adding an extra passkey

## Testing
- npx tsc --noEmit *(fails: existing global handler scripts are reported as unused)*

------
https://chatgpt.com/codex/tasks/task_e_690899b76be4832ebcfc56ed8b24eb8f